### PR TITLE
Reload networkd instead of restart

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -16,7 +16,7 @@
 - name: Restart networkd
   systemd:
     name: "systemd-networkd"
-    state: restarted
+    state: reloaded
     enabled: "yes"
   async: 45
   poll: 0


### PR DESCRIPTION
`restarted` will always bounce the unit. `reloaded` will always reload and if the service is not running at the moment of the reload, it is started.

(from https://docs.ansible.com/ansible/latest/collections/ansible/builtin/systemd_service_module.html#parameter-state )

PS: I know PRs on GH are ignored, this is merely to document the change